### PR TITLE
Fix build on Ubuntu 24.04

### DIFF
--- a/third_party/patches/linenoise/linenoise.c.patch
+++ b/third_party/patches/linenoise/linenoise.c.patch
@@ -1,5 +1,7 @@
---- linenoise.c.new	2015-04-13 02:38:43.000000000 -0500
-+++ linenoise.c	2017-02-21 09:47:42.000000000 -0600
+diff --git a/./original_linenoise.c b/patch_1_linenoise.c
+index c10557d0..7852f5d6 100644
+--- a/./original_linenoise.c
++++ b/patch_1_linenoise.c
 @@ -1,7 +1,5 @@
 -/* linenoise.c -- VERSION 1.0
 - *
@@ -10,7 +12,15 @@
   *
   * You can find the latest source code at:
   *
-@@ -120,6 +118,7 @@
+@@ -111,6 +109,7 @@
+ #include <stdio.h>
+ #include <errno.h>
+ #include <string.h>
++#include <strings.h>
+ #include <stdlib.h>
+ #include <ctype.h>
+ #include <sys/types.h>
+@@ -120,6 +119,7 @@
  
  #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
  #define LINENOISE_MAX_LINE 4096
@@ -18,7 +28,7 @@
  static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
  static linenoiseCompletionCallback *completionCallback = NULL;
  
-@@ -774,6 +773,10 @@
+@@ -774,6 +774,10 @@ static int linenoiseEdit(int stdin_fd, int stdout_fd, char *buf, size_t buflen,
              history_len--;
              free(history[history_len]);
              if (mlmode) linenoiseEditMoveEnd(&l);
@@ -29,7 +39,7 @@
              return (int)l.len;
          case CTRL_C:     /* ctrl-c */
              errno = EAGAIN;
-@@ -940,10 +943,12 @@
+@@ -940,10 +944,12 @@ static int linenoiseRaw(char *buf, size_t buflen, const char *prompt) {
          /* Not a tty: read from file / pipe. */
          if (fgets(buf, buflen, stdin) == NULL) return -1;
          count = strlen(buf);
@@ -42,7 +52,7 @@
      } else {
          /* Interactive editing. */
          if (enableRawMode(STDIN_FILENO) == -1) return -1;
-@@ -970,10 +975,12 @@
+@@ -970,10 +976,12 @@ char *linenoise(const char *prompt) {
          fflush(stdout);
          if (fgets(buf,LINENOISE_MAX_LINE,stdin) == NULL) return NULL;
          len = strlen(buf);
@@ -55,7 +65,7 @@
          return strdup(buf);
      } else {
          count = linenoiseRaw(buf,LINENOISE_MAX_LINE,prompt);
-@@ -1021,12 +1028,29 @@
+@@ -1021,12 +1029,29 @@ int linenoiseHistoryAdd(const char *line) {
          memset(history,0,(sizeof(char*)*history_max_len));
      }
  

--- a/third_party/src/glog/CMakeLists.txt
+++ b/third_party/src/glog/CMakeLists.txt
@@ -89,7 +89,7 @@ else()
   # Check if we are using pthreads.
   find_package(Threads)
   # 'CMAKE_HAVE_LIBC_PTHREAD' handles the case when glibc contains pthreads.
-  if (CMAKE_HAVE_PTHREAD_H STREQUAL "YES" OR CMAKE_HAVE_LIBC_PTHREAD STREQUAL "YES")
+  if (CMAKE_HAVE_PTHREAD_H OR CMAKE_HAVE_LIBC_PTHREAD)
     set(HAVE_LIBPTHREAD 1)
     set(HAVE_PTHREAD 1)
     set(HAVE_RWLOCK 1)

--- a/third_party/src/glog/CMakeLists.txt
+++ b/third_party/src/glog/CMakeLists.txt
@@ -88,7 +88,8 @@ else()
 
   # Check if we are using pthreads.
   find_package(Threads)
-  if (CMAKE_HAVE_PTHREAD_H)
+  # 'CMAKE_HAVE_LIBC_PTHREAD' handles the case when glibc contains pthreads.
+  if (CMAKE_HAVE_PTHREAD_H STREQUAL "YES" OR CMAKE_HAVE_LIBC_PTHREAD STREQUAL "YES")
     set(HAVE_LIBPTHREAD 1)
     set(HAVE_PTHREAD 1)
     set(HAVE_RWLOCK 1)


### PR DESCRIPTION
The build of Quickstep fails on Ubuntu 24.04 but is successful on Ubuntu 22.04. The following two errors occur during the build:

1.  In linenoise.c, the function definition for 'strncmp' is missing.
2. In glog, pthreads are not found despite being present.

The PR updates:

A.  The patch for linenoise.c to explicitly include '<strings.h>'.
B. The CMake file for glog to recognize pthreads on Ubuntu 24.04.

After the changes mentioned above, the build succeeds on Ubuntu 22.04 and Ubuntu 24.04.